### PR TITLE
Allow Users to Hide Events from public Index

### DIFF
--- a/src/app/components/cd-listitem/cd-listitem.component.html
+++ b/src/app/components/cd-listitem/cd-listitem.component.html
@@ -25,6 +25,8 @@
                             <img src="{{ userImage }}" width="32px">
                             {{ username }}
                         </button>
+                        <button *ngIf='auth.getUserID() == data.userID && data.isDeleted' (click)="restoreEvent()" mat-button click-stop-propagation><mat-icon>delete</mat-icon></button>
+                        <button *ngIf='auth.getUserID() == data.userID && !data.isDeleted' (click)="deleteEvent()" mat-button click-stop-propagation><mat-icon>delete_outline</mat-icon></button>
                         <button mat-button click-stop-propagation (click)="incrementCountInternal()"><mat-icon>favorite_border</mat-icon> {{ data.count }}</button>
                         <button mat-button click-stop-propagation (click)="copyID()"><mat-icon>share</mat-icon></button>
                     </div>

--- a/src/app/components/cd-listitem/cd-listitem.component.html
+++ b/src/app/components/cd-listitem/cd-listitem.component.html
@@ -25,8 +25,8 @@
                             <img src="{{ userImage }}" width="32px">
                             {{ username }}
                         </button>
-                        <button *ngIf='auth.getUserID() == data.userID && data.isDeleted' (click)="restoreEvent()" mat-button click-stop-propagation><mat-icon>delete</mat-icon></button>
-                        <button *ngIf='auth.getUserID() == data.userID && !data.isDeleted' (click)="deleteEvent()" mat-button click-stop-propagation><mat-icon>delete_outline</mat-icon></button>
+                        <button *ngIf='auth.getUserID() == data.userID && data.isDeleted && data.userID != "guest-user"' (click)="restoreEvent()" mat-button click-stop-propagation><mat-icon>delete</mat-icon></button>
+                        <button *ngIf='auth.getUserID() == data.userID && !data.isDeleted && data.userID != "guest-user"' (click)="deleteEvent()" mat-button click-stop-propagation><mat-icon>delete_outline</mat-icon></button>
                         <button mat-button click-stop-propagation (click)="incrementCountInternal()"><mat-icon>favorite_border</mat-icon> {{ data.count }}</button>
                         <button mat-button click-stop-propagation (click)="copyID()"><mat-icon>share</mat-icon></button>
                     </div>

--- a/src/app/components/cd-listitem/cd-listitem.component.html
+++ b/src/app/components/cd-listitem/cd-listitem.component.html
@@ -25,8 +25,8 @@
                             <img src="{{ userImage }}" width="32px">
                             {{ username }}
                         </button>
-                        <button *ngIf='auth.getUserID() == data.userID && data.isDeleted && data.userID != "guest-user"' (click)="restoreEvent()" mat-button click-stop-propagation><mat-icon>delete</mat-icon></button>
-                        <button *ngIf='auth.getUserID() == data.userID && !data.isDeleted && data.userID != "guest-user"' (click)="deleteEvent()" mat-button click-stop-propagation><mat-icon>delete_outline</mat-icon></button>
+                        <button *ngIf='auth.getUserID() == data.userID && data.isDeleted && data.userID != "guest-user"' (click)="restoreEvent()" mat-button click-stop-propagation><mat-icon>delete</mat-icon>Hidden</button>
+                        <button *ngIf='auth.getUserID() == data.userID && !data.isDeleted && data.userID != "guest-user"' (click)="deleteEvent()" mat-button click-stop-propagation><mat-icon>delete_outline</mat-icon>Visible</button>
                         <button mat-button click-stop-propagation (click)="incrementCountInternal()"><mat-icon>favorite_border</mat-icon> {{ data.count }}</button>
                         <button mat-button click-stop-propagation (click)="copyID()"><mat-icon>share</mat-icon></button>
                     </div>

--- a/src/app/components/cd-listitem/cd-listitem.component.ts
+++ b/src/app/components/cd-listitem/cd-listitem.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 import { FirebaseEventService } from "../../services/firebase-event.service"
+import { AuthService } from "../../services/auth.service"
 
 import { Event } from '../../models/event.model';
 
@@ -17,7 +18,10 @@ export class CdListitemComponent implements OnInit {
   userImage: string;
   userUrl: string;
 
-  constructor(private eventService: FirebaseEventService) { }
+  constructor(
+    private eventService: FirebaseEventService,
+    public auth: AuthService,
+    ) { }
 
   ngOnInit(): void {
     // setup URL to user page
@@ -32,6 +36,16 @@ export class CdListitemComponent implements OnInit {
 
   incrementCountInternal(): void {
     incrementCount(this.eventService, this.data);
+  }
+
+  deleteEvent(): void {
+    this.data.isDeleted = true;
+    this.eventService.updateItem(this.data);
+  }
+
+  restoreEvent(): void {
+    this.data.isDeleted = false;
+    this.eventService.updateItem(this.data);
   }
 
   // Wrapper function for copyID from utils

--- a/src/app/components/create-cd/create-cd.component.ts
+++ b/src/app/components/create-cd/create-cd.component.ts
@@ -95,6 +95,7 @@ export class CreateCdComponent implements OnInit {
       time_unix: (new Date(descriptionForm['datetime']).getTime() / 1000) + (60*60),
       tags: this.processTags(descriptionForm['tags']),
       userID: currentUserID,
+      isDeleted: false
     }
 
     // DO NOT execute this if for preview only

--- a/src/app/components/user-dashboard/user-dashboard.component.ts
+++ b/src/app/components/user-dashboard/user-dashboard.component.ts
@@ -33,7 +33,6 @@ export class UserDashboardComponent implements OnInit {
       this.eventService.getItemByID(eventID).then(event => {
         if (event != undefined) {
           this.userEvents.push(event);
-          console.log(event);
         }
       });
     }

--- a/src/app/models/event.model.ts
+++ b/src/app/models/event.model.ts
@@ -8,4 +8,5 @@ export interface Event {
   time_unix?: number;
   tags?: string[];
   userID?: string;
+  isDeleted?: boolean;
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -84,8 +84,6 @@ export class AuthService {
       data["events"] = user.events;
     }
 
-    console.log(data);
     return userRef.set(data, { merge: true });
   }
-
 }

--- a/src/app/services/firebase-event.service.ts
+++ b/src/app/services/firebase-event.service.ts
@@ -22,8 +22,8 @@ export class FirebaseEventService {
   countdownDoc: AngularFirestoreDocument<Event>;
 
   constructor(public afs:AngularFirestore) {
-    this.countdownCollection = this.afs.collection('countdowns', ref => ref.orderBy('count', 'desc'));
-    this.featuredCollection  = this.afs.collection('countdowns', ref => ref.where("isFeatured", "==", true));
+    this.countdownCollection = this.afs.collection('countdowns', ref => ref.where("isDeleted", "==", false).orderBy('count', 'desc'));
+    this.featuredCollection  = this.afs.collection('countdowns', ref => ref.where("isDeleted", "==", false).where("isFeatured", "==", true));
 
     this.countdowns = this.countdownCollection.snapshotChanges().pipe(
       map((changes): Event[] => {
@@ -45,7 +45,7 @@ export class FirebaseEventService {
   }
 
   getTopCountdowns(numberToFetch: number = 10): Observable<Event[]> {
-    let cdCollection = this.afs.collection('countdowns', ref => ref.orderBy('count', 'desc').limit(numberToFetch));
+    let cdCollection = this.afs.collection('countdowns', ref => ref.where("isDeleted", "==", false).orderBy('count', 'desc').limit(numberToFetch));
 
     let data = cdCollection.snapshotChanges().pipe(
       map((changes): Event[] => {


### PR DESCRIPTION
- [x] Allow Users to Hide Events, i.e., Not visible to others without a direct link
- [x] Closes #21 

> Note: This does not delete the Event from DB. It merely flips a boolean value, causing it not to appear in public indices. It will still be visible to users with the link to the Event.

This means that you will be able to create and share private Events only within a limited group, without other visitors of the Application, aware of it.